### PR TITLE
Use https instead of http

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -33,13 +33,6 @@ In addition to launching apps, the main SMART specification defines a
   the community of users and implementers.
 </blockquote>
 
-<blockquote id="canonicals-note" class="stu-note">
-  <strong>This version of the implementation guide uses canonical URLs that differ from the ones
-  used published version.</strong> This CI version of the guide is published at
-  [https://fhir.fi/finnish-smart](https://fhir.fi/finnish-smart). However, the official release
-  will be published in [https://hl7.fi/fhir/finnish-smart](https://hl7.fi/fhir/finnish-smart) and will also use that address for the base of canonical URLs in the guide.
-</blockquote>
-
 #### Companion Specifications
 
 There is a separate implementation guide for [Finnish Base Profiles](../finnish-base-profiles/)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -1,5 +1,5 @@
 id: hl7.fhir.fi.smart
-canonical: http://hl7.fi/fhir/finnish-smart
+canonical: https://hl7.fi/fhir/finnish-smart
 name: FinnishSmart
 title: Finnish Implementation Guide for SMART App Launch 
 description: Guidelines for using the SMART App Launch mechanism in Finland.
@@ -28,7 +28,6 @@ pages:
     title: Downloads
   history.md:
     title: Version History
-
 
 menu:
   Home: index.html


### PR DESCRIPTION
And let's use the hl7 canonical for CI builds, instead of the fhir.fi. It should be safe and OK now that we also have the official publish location set up.