### PR TITLE
Restore CI mode

### DIFF
--- a/publication-request.json
+++ b/publication-request.json
@@ -1,11 +1,11 @@
 {
   "package-id" : "hl7.fhir.fi.smart",
-  "version" : "1.0.0",
-  "path" : "https://hl7.fi/fhir/finnish-smart/1.0.0",
-  "mode" : "milestone",
-  "status" : "trial-use",
+  "version" : "1.0.1",
+  "path" : "https://hl7.fi/fhir/finnish-smart/1.0.1",
+  "mode" : "working",
+  "status" : "draft",
   "sequence" : "STU 1",
-  "desc" : "Release 1.0.0, STU 1",
-  "descmd" : "Release 1.0.0, STU 1",
+  "desc" : "CI snapshot for v 1.0.1",
+  "descmd" : "CI snapshot for v 1.0.1",
   "first" : "false"
 }

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,7 +1,7 @@
 {
   "package-id" : "hl7.fhir.fi.smart",
-  "version" : "1.0.1",
-  "path" : "https://hl7.fi/fhir/finnish-smart/1.0.1",
+  "version" : "1.0.1-cibuild",
+  "path" : "https://hl7.fi/fhir/finnish-smart/1.0.1-cibuild",
   "mode" : "working",
   "status" : "draft",
   "sequence" : "STU 1",

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -4,7 +4,7 @@ name: FinnishSmart
 title: Finnish Implementation Guide for SMART App Launch 
 description: Guidelines for using the SMART App Launch mechanism in Finland.
 status: draft # draft | active | retired | unknown
-version: 1.0.1-snapshot
+version: 1.0.1-cibuild
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2022+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,11 +3,11 @@ canonical: https://hl7.fi/fhir/finnish-smart
 name: FinnishSmart
 title: Finnish Implementation Guide for SMART App Launch 
 description: Guidelines for using the SMART App Launch mechanism in Finland.
-status: active # draft | active | retired | unknown
-version: 1.0.0
+status: draft # draft | active | retired | unknown
+version: 1.0.1-snapshot
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2022+
-releaseLabel: trial-use # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: urn:iso:std:iso:3166#FI "Finland" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:


### PR DESCRIPTION
To be merged after the release formalities of the version 1.0.0. So that we keep the working versions clearly separated from the published one.